### PR TITLE
Add support for sending fake clocks in the context

### DIFF
--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/stretchr/testify v1.6.1
 	k8s.io/apimachinery v0.20.1
 )
+
+replace github.com/puppetlabs/leg/timeutil => ../timeutil

--- a/scheduler/recovery_test.go
+++ b/scheduler/recovery_test.go
@@ -104,7 +104,6 @@ func TestRecoverySchedulerRetryCountReset(t *testing.T) {
 						backoff.MaxRetries(10),
 					),
 					successDuration-(500*time.Millisecond),
-					backoff.ResetAfterWithClock(dc),
 				),
 			),
 		),

--- a/timeutil/CHANGELOG.md
+++ b/timeutil/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Add clockctx package to enable a fake clock to be passed through a context.
+
 ## [0.2.0] - 2021-01-06
 
 ### Added

--- a/timeutil/README.md
+++ b/timeutil/README.md
@@ -1,0 +1,29 @@
+# timeutil
+
+This module augments Go's standard library time package.
+
+## Packages
+
+### clock
+
+The clock package provides an abstraction over most of the types and methods in `time` that depend on a current wall time.
+
+### clock/k8sext
+
+This package adapts the [Kubernetes API machinery clock fakes](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/clock) to work with our clock package.
+
+### clockctx
+
+The clockctx package allows a clock fake to be passed through a [context](https://golang.org/pkg/context/). It also provides its own `WithTimeout` and `WithDeadline` functions that use a fake clock.
+
+### backoff
+
+The backoff package contains algorithms for determining how long to wait between attempting work.
+
+### retry
+
+The retry package builds on the backoff package, providing a utility to automatically attempt to perform work multiple times.
+
+### iso8601
+
+The iso8601 package contains types to work with ISO 8601 date/time formats not covered by the standard library: durations, intervals, and recurring intervals.

--- a/timeutil/pkg/backoff/backoff.go
+++ b/timeutil/pkg/backoff/backoff.go
@@ -1,6 +1,9 @@
 package backoff
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Backoff is a combination of a generator of backoff durations and zero or more
 // rules that adjust the generated duration amounts.
@@ -13,7 +16,7 @@ type Backoff struct {
 }
 
 // Next provides a new backoff amount to delay work by.
-func (b *Backoff) Next() (next time.Duration, err error) {
+func (b *Backoff) Next(ctx context.Context) (next time.Duration, err error) {
 	generate := true
 	if b.r != nil {
 		generate, next, err = b.r.ApplyBefore()
@@ -23,7 +26,7 @@ func (b *Backoff) Next() (next time.Duration, err error) {
 	}
 
 	if generate {
-		next, err = b.g.Next()
+		next, err = b.g.Next(ctx)
 		if err != nil {
 			return 0, err
 		}

--- a/timeutil/pkg/backoff/backoff_test.go
+++ b/timeutil/pkg/backoff/backoff_test.go
@@ -1,6 +1,7 @@
 package backoff_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 var randFactory = rand.NewPCGFactory(rand.OneSeeder)
 
 func TestBuild(t *testing.T) {
+	ctx := context.Background()
+
 	f := backoff.Build(
 		backoff.Linear(5*time.Second),
 		backoff.MinBound(7*time.Second),
@@ -35,7 +38,7 @@ func TestBuild(t *testing.T) {
 		30 * time.Second,
 	}
 	for i, step := range expected {
-		wait, err := b.Next()
+		wait, err := b.Next(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, step, wait, "step #%d", i)
 	}

--- a/timeutil/pkg/backoff/constant.go
+++ b/timeutil/pkg/backoff/constant.go
@@ -1,12 +1,15 @@
 package backoff
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type constantGenerator struct {
 	step time.Duration
 }
 
-func (cg *constantGenerator) Next() (time.Duration, error) {
+func (cg *constantGenerator) Next(ctx context.Context) (time.Duration, error) {
 	return cg.step, nil
 }
 

--- a/timeutil/pkg/backoff/constant_test.go
+++ b/timeutil/pkg/backoff/constant_test.go
@@ -1,6 +1,7 @@
 package backoff_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,11 +11,13 @@ import (
 )
 
 func TestConstant(t *testing.T) {
+	ctx := context.Background()
+
 	g, err := backoff.Constant(5 * time.Second).New()
 	require.NoError(t, err)
 
 	for i := 0; i < 100; i++ {
-		wait, err := g.Next()
+		wait, err := g.Next(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, 5*time.Second, wait, "iteration #%d", i)
 	}

--- a/timeutil/pkg/backoff/exponential.go
+++ b/timeutil/pkg/backoff/exponential.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -13,7 +14,7 @@ type exponentialGenerator struct {
 	factor  float64
 }
 
-func (eg *exponentialGenerator) Next() (time.Duration, error) {
+func (eg *exponentialGenerator) Next(ctx context.Context) (time.Duration, error) {
 	var exp float64
 	switch eg.factor {
 	case 2.0:
@@ -63,7 +64,7 @@ type decorrelatedExponentialGenerator struct {
 
 var _ RuleInjector = &decorrelatedExponentialGenerator{}
 
-func (deg *decorrelatedExponentialGenerator) Next() (next time.Duration, err error) {
+func (deg *decorrelatedExponentialGenerator) Next(ctx context.Context) (next time.Duration, err error) {
 	generate := true
 	if deg.rule != nil {
 		generate, next, err = deg.rule.ApplyBefore()

--- a/timeutil/pkg/backoff/exponential_test.go
+++ b/timeutil/pkg/backoff/exponential_test.go
@@ -1,6 +1,7 @@
 package backoff_test
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestExponential(t *testing.T) {
+	ctx := context.Background()
+
 	g, err := backoff.Exponential(10*time.Second, 60.0).New()
 	require.NoError(t, err)
 
@@ -26,13 +29,15 @@ func TestExponential(t *testing.T) {
 		math.MaxInt64,
 	}
 	for i, step := range expected {
-		wait, err := g.Next()
+		wait, err := g.Next(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, step, wait, "step #%d", i)
 	}
 }
 
 func TestDecorrelatedExponential(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		Name     string
 		Factory  backoff.GeneratorFactory
@@ -89,7 +94,7 @@ func TestDecorrelatedExponential(t *testing.T) {
 			}
 
 			for i, step := range test.Expected {
-				wait, err := g.Next()
+				wait, err := g.Next(ctx)
 				require.NoError(t, err)
 				assert.Equal(t, step, wait, "step #%d", i)
 			}

--- a/timeutil/pkg/backoff/gen.go
+++ b/timeutil/pkg/backoff/gen.go
@@ -1,13 +1,14 @@
 package backoff
 
 import (
+	"context"
 	"time"
 )
 
 // Generator produces new durations based on a particular algorithm.
 type Generator interface {
 	// Next returns the next duration to back off by.
-	Next() (time.Duration, error)
+	Next(ctx context.Context) (time.Duration, error)
 }
 
 // GeneratorFactory provides a Goroutine-safe factory for creating generators of

--- a/timeutil/pkg/backoff/linear.go
+++ b/timeutil/pkg/backoff/linear.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"context"
 	"math"
 	"time"
 )
@@ -10,7 +11,7 @@ type linearGenerator struct {
 	step time.Duration
 }
 
-func (lg *linearGenerator) Next() (time.Duration, error) {
+func (lg *linearGenerator) Next(ctx context.Context) (time.Duration, error) {
 	if lg.n < math.MaxInt64 {
 		lg.n++
 	}

--- a/timeutil/pkg/backoff/linear_test.go
+++ b/timeutil/pkg/backoff/linear_test.go
@@ -1,6 +1,7 @@
 package backoff_test
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -11,17 +12,21 @@ import (
 )
 
 func TestLinear(t *testing.T) {
+	ctx := context.Background()
+
 	g, err := backoff.Linear(5 * time.Second).New()
 	require.NoError(t, err)
 
 	for i := 0; i < 100; i++ {
-		wait, err := g.Next()
+		wait, err := g.Next(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, 5*time.Duration(i+1)*time.Second, wait, "iteration #%d", i)
 	}
 }
 
 func TestLinearWraparound(t *testing.T) {
+	ctx := context.Background()
+
 	g, err := backoff.Linear(1 << 61).New()
 	require.NoError(t, err)
 
@@ -34,7 +39,7 @@ func TestLinearWraparound(t *testing.T) {
 		math.MaxInt64,
 	}
 	for i, step := range expected {
-		wait, err := g.Next()
+		wait, err := g.Next(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, int64(step), int64(wait), "step #%d", i)
 	}

--- a/timeutil/pkg/backoff/reset_test.go
+++ b/timeutil/pkg/backoff/reset_test.go
@@ -1,6 +1,7 @@
 package backoff_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 )
 
 func TestResetAfter(t *testing.T) {
+	ctx := context.Background()
+
 	type expected struct {
 		Duration  time.Duration
 		Error     error
@@ -73,7 +76,7 @@ func TestResetAfter(t *testing.T) {
 			require.NoError(t, err)
 
 			for i, step := range test.Expected {
-				next, err := g.Next()
+				next, err := g.Next(ctx)
 				assert.Equal(t, step.Error, err, "step #%d", i)
 				assert.Equal(t, step.Duration, next, "step #%d", i)
 

--- a/timeutil/pkg/clock/afterfunc.go
+++ b/timeutil/pkg/clock/afterfunc.go
@@ -1,0 +1,77 @@
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+type funcTimer struct {
+	delegate Timer
+	mut      sync.Mutex
+	cancel   chan struct{}
+	fn       func()
+}
+
+var _ Timer = &funcTimer{}
+
+func (ft *funcTimer) C() <-chan time.Time {
+	return nil
+}
+
+func (ft *funcTimer) Stop() bool {
+	r := ft.delegate.Stop()
+	if r {
+		ft.mut.Lock()
+		defer ft.mut.Unlock()
+
+		close(ft.cancel)
+		ft.cancel = nil
+	}
+
+	return r
+}
+
+func (ft *funcTimer) Reset(d time.Duration) bool {
+	ft.delegate.Reset(d)
+	return ft.schedule()
+}
+
+func (ft *funcTimer) schedule() bool {
+	ft.mut.Lock()
+	defer ft.mut.Unlock()
+
+	if ft.cancel != nil {
+		return true
+	}
+
+	ch := make(chan struct{})
+	go func() {
+		select {
+		case <-ft.delegate.C():
+			ft.mut.Lock()
+			ft.cancel = nil
+			ft.mut.Unlock()
+			ft.fn()
+		case <-ch:
+		}
+	}()
+
+	ft.cancel = ch
+	return false
+}
+
+// AfterFunc abstracts time.AfterFunc to use a Clock.
+//
+// Like the time package, the returned Timer will never report a time on its
+// channel. The semantics of the Stop and Reset methods are also the same.
+func AfterFunc(c Clock, d time.Duration, fn func()) Timer {
+	if c == RealClock {
+		return &realTimer{time.AfterFunc(d, fn)}
+	}
+	ft := &funcTimer{
+		delegate: c.NewTimer(d),
+		fn:       fn,
+	}
+	ft.schedule()
+	return ft
+}

--- a/timeutil/pkg/clock/afterfunc_test.go
+++ b/timeutil/pkg/clock/afterfunc_test.go
@@ -1,0 +1,74 @@
+package clock_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/puppetlabs/leg/timeutil/pkg/clock"
+	"github.com/puppetlabs/leg/timeutil/pkg/clock/k8sext"
+	"github.com/stretchr/testify/assert"
+	testclock "k8s.io/apimachinery/pkg/util/clock"
+)
+
+func TestAfterFunc(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var calls uint32
+	ch := make(chan uint32)
+
+	uc := testclock.NewFakeClock(time.Now())
+	mc := k8sext.NewClock(uc)
+	timer := clock.AfterFunc(mc, 10*time.Minute, func() {
+		// Clear anything currently on the channel. Next read will be the call
+		// value.
+	clear:
+		for {
+			select {
+			case <-ch:
+			default:
+				break clear
+			}
+		}
+		ch <- atomic.AddUint32(&calls, 1)
+	})
+
+	// Forward the clock 30 minutes. The timer should fire exactly once.
+	uc.Step(30 * time.Minute)
+	select {
+	case i := <-ch:
+		assert.Equal(t, uint32(1), i)
+	case <-ctx.Done():
+		assert.Fail(t, "context expired waiting for timer")
+	}
+
+	assert.False(t, timer.Stop())
+
+	// Now reset the timer, which will put the function in a state to be called
+	// again.
+	assert.False(t, timer.Reset(10*time.Minute))
+	uc.Step(5 * time.Minute)
+
+	// Stop the timer and move the clock past.
+	assert.True(t, timer.Stop())
+	uc.Step(30 * time.Minute)
+
+	// Finally reset once more.
+	assert.False(t, timer.Reset(10*time.Minute))
+
+	// Move forward 5 minutes, then reset the timer again. The function should
+	// move with us.
+	uc.Step(5 * time.Minute)
+	assert.True(t, timer.Reset(10*time.Minute))
+
+	uc.Step(5 * time.Minute)
+	uc.Step(30 * time.Minute)
+	select {
+	case i := <-ch:
+		assert.Equal(t, uint32(2), i)
+	case <-ctx.Done():
+		assert.Fail(t, "context expired waiting for timer")
+	}
+}

--- a/timeutil/pkg/clock/clock.go
+++ b/timeutil/pkg/clock/clock.go
@@ -8,7 +8,9 @@
 // easy-to-use adapter in the package clock/k8sext.
 package clock
 
-import "time"
+import (
+	"time"
+)
 
 // PassiveClock is a clock that provides timing information but not the ability
 // to schedule events for the future.

--- a/timeutil/pkg/clockctx/context.go
+++ b/timeutil/pkg/clockctx/context.go
@@ -1,0 +1,29 @@
+package clockctx
+
+import (
+	"context"
+
+	"github.com/puppetlabs/leg/timeutil/pkg/clock"
+)
+
+type contextKey int
+
+const (
+	clockContextKey contextKey = iota
+)
+
+// WithClock sets the given clock in the context.
+func WithClock(ctx context.Context, c clock.Clock) context.Context {
+	return context.WithValue(ctx, clockContextKey, c)
+}
+
+// Clock retrieves the current clock set in the context, defaulting to
+// clock.RealClock.
+func Clock(ctx context.Context) clock.Clock {
+	c, ok := ctx.Value(clockContextKey).(clock.Clock)
+	if !ok {
+		c = clock.RealClock
+	}
+
+	return c
+}

--- a/timeutil/pkg/clockctx/deadline.go
+++ b/timeutil/pkg/clockctx/deadline.go
@@ -1,0 +1,187 @@
+// Portions of this file are derived from Go's context package.
+//
+// https://go.googlesource.com/go/+/go1.14.15/src/context/context.go
+//
+// Licensed under a three-clause BSD-style license. A copy of the full license
+// document is included in this distribution in the file `deadline.go.LICENSE`.
+
+package clockctx
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/puppetlabs/leg/timeutil/pkg/clock"
+)
+
+// closedChan is a reusable closed channel.
+var closedChan = make(chan struct{})
+
+func init() {
+	close(closedChan)
+}
+
+// WithDeadlineOfClock sets the given context deadline to be no later than the
+// given time under the auspices of a particular clock.
+//
+// This function delegates to context.WithDeadline if c == clock.RealClock.
+// Otherwise, it is vastly less efficient than the standard library's context
+// package equivalent because it does not have access to internal data
+// associated with those contexts. In performance-sensitive applications, this
+// function must be used with care.
+//
+// This function does not set the clock in the context. To do that, use
+// clockctx.WithDeadline(clockctx.WithClock(ctx, c), d) instead.
+//
+// Note that using this method in combination with a clock that moves slower
+// than wall time and downstream calls to the standard library
+// context.WithDeadline/context.WithTimeout methods may result in strange,
+// undesirable behavior.
+func WithDeadlineOfClock(ctx context.Context, c clock.Clock, d time.Time) (context.Context, context.CancelFunc) {
+	if c == clock.RealClock {
+		return context.WithDeadline(ctx, d)
+	}
+	// Note that this implementation does not shortcut if the deadline of the
+	// parent is before the requested time, as the actual passage of time among
+	// implementations of clock.Clock may vary. However, it will reduce the
+	// deadline to the parent's.
+	if cur, ok := ctx.Deadline(); ok && cur.Before(d) {
+		d = cur
+	}
+	tctx := &timerCtx{
+		Context:  ctx,
+		clock:    c,
+		deadline: d,
+	}
+	propagateCancel(ctx, tctx)
+	dur := time.Until(d)
+	if dur <= 0 {
+		tctx.cancel(context.DeadlineExceeded) // deadline has already passed
+		return tctx, func() { tctx.cancel(context.Canceled) }
+	}
+	tctx.mu.Lock()
+	defer tctx.mu.Unlock()
+	if tctx.err == nil {
+		tctx.timer = clock.AfterFunc(c, dur, func() {
+			tctx.cancel(context.DeadlineExceeded)
+		})
+	}
+	return tctx, func() { tctx.cancel(context.Canceled) }
+}
+
+// WithTimeoutOfClock is equivalent to WithDeadlineOfClock(ctx, c,
+// c.Now().Add(timeout)).
+func WithTimeoutOfClock(ctx context.Context, c clock.Clock, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return WithDeadlineOfClock(ctx, c, c.Now().Add(timeout))
+}
+
+// WithDeadline behaves exactly like context.WithDeadline but uses the clock
+// from the context, if any, to determine which clock to use for the deadline.
+//
+// This function delegates to WithDeadlineOfClock and has all of the caveats
+// associated with it.
+func WithDeadline(ctx context.Context, d time.Time) (context.Context, context.CancelFunc) {
+	return WithDeadlineOfClock(ctx, Clock(ctx), d)
+}
+
+// WithTimeout behaves exactly like context.WithTimeout but uses the clock from
+// the context, if any, to determine which clock to use for the timeout.
+//
+// This function delegates to WithTimeoutOfClock and has all of the caveats
+// associated with it.
+func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return WithTimeoutOfClock(ctx, Clock(ctx), timeout)
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent context.Context, child *timerCtx) {
+	done := parent.Done()
+	if done == nil {
+		return // parent is never canceled
+	}
+
+	select {
+	case <-done:
+		// parent is already canceled
+		child.cancel(parent.Err())
+		return
+	default:
+	}
+
+	go func() {
+		select {
+		case <-parent.Done():
+			child.cancel(parent.Err())
+		case <-child.Done():
+		}
+	}()
+}
+
+// A timerCtx carries a timer and a deadline. It embeds the implementation of
+// the Go library's cancelCtx to implement Done and Err as well.
+type timerCtx struct {
+	context.Context
+	mu    sync.Mutex    // protects following fields
+	done  chan struct{} // created lazily, closed by first cancel call
+	err   error         // set to non-nil by the first cancel call
+	clock clock.Clock
+	timer clock.Timer
+
+	deadline time.Time
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) {
+	return c.deadline, true
+}
+
+func (c *timerCtx) Done() <-chan struct{} {
+	c.mu.Lock()
+	if c.done == nil {
+		c.done = make(chan struct{})
+	}
+	d := c.done
+	c.mu.Unlock()
+	return d
+}
+
+func (c *timerCtx) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+	return err
+}
+
+func (c *timerCtx) String() string {
+	return contextName(c.Context) + ".WithDeadline(" +
+		c.deadline.String() + " [" +
+		c.deadline.Sub(c.clock.Now()).String() + "])"
+}
+
+func (c *timerCtx) cancel(err error) {
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return // already canceled
+	}
+	c.err = err
+	if c.done == nil {
+		c.done = closedChan
+	} else {
+		close(c.done)
+	}
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.mu.Unlock()
+}
+
+func contextName(c context.Context) string {
+	if s, ok := c.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return reflect.TypeOf(c).String()
+}

--- a/timeutil/pkg/clockctx/deadline.go.LICENSE
+++ b/timeutil/pkg/clockctx/deadline.go.LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/timeutil/pkg/clockctx/deadline_test.go
+++ b/timeutil/pkg/clockctx/deadline_test.go
@@ -1,0 +1,33 @@
+package clockctx_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/puppetlabs/leg/timeutil/pkg/clock/k8sext"
+	"github.com/puppetlabs/leg/timeutil/pkg/clockctx"
+	"github.com/stretchr/testify/assert"
+	testclock "k8s.io/apimachinery/pkg/util/clock"
+)
+
+func TestWithDeadlineOfClock(t *testing.T) {
+	// Parent context will expire after 10 actual seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uc := testclock.NewFakeClock(time.Now())
+	mc := k8sext.NewClock(uc)
+
+	tctx, _ := clockctx.WithDeadlineOfClock(context.Background(), mc, mc.Now().Add(10*time.Minute))
+
+	// Forward by 15 minutes.
+	uc.Step(15 * time.Minute)
+	select {
+	case <-tctx.Done():
+	case <-ctx.Done():
+		assert.Fail(t, "context expired waiting for deadline of context under test")
+	}
+
+	assert.Equal(t, context.DeadlineExceeded, tctx.Err())
+}


### PR DESCRIPTION
This change makes it possible to expose a clock in the context. It also provides utility methods to use such a clock in the same form as the standard library context package, i.e., `WithTimeout` and `WithDeadline` now respect fake clocks.

Code that could take advantage of passing a clock through the context has been updated to do so.