### PR TITLE
Update k8s manifest parse logic

### DIFF
--- a/k8sutil/CHANGELOG.md
+++ b/k8sutil/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+* Improve the manifest parsing logic based on standard handling.
+
 ## [0.6.0] - 2021-07-16
 
 ### Added


### PR DESCRIPTION
Update the Kubernetes manifest parse logic based partly on the [StreamVisitor Visit](https://github.com/kubernetes/cli-runtime/blob/3505ace81723131a87a6a089b8a4c655681cc3f0/pkg/resource/visitor.go#L550) function in https://github.com/kubernetes/cli-runtime.

Simplifies the logic and handles a necessary use-case.