### PR TITLE
Support go 1.17 and 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
         module: ${{ fromJSON(needs.init.outputs.modules) }}
     defaults:
       run:


### PR DESCRIPTION
Officially support `go` 1.17 and 1.18.
Technically this only changes the test matrix, but 1.16 is no longer supported.

(`vaultutil` specifically should not be expected to work with 1.16 due to specific `vault` dependency requirements)