### PR TITLE
Vault unseal is now optional

### DIFF
--- a/vaultutil/pkg/vault/init.go
+++ b/vaultutil/pkg/vault/init.go
@@ -33,7 +33,7 @@ func (vim *VaultInitializationManager) initializeSystem(ctx context.Context) err
 	}
 
 	var err error
-	if credentials.RootToken == "" || credentials.UnsealKeys[0] == "" {
+	if credentials.RootToken == "" {
 		credentials, err = vim.vaultSystemManager.GetCredentials(ctx)
 		if err != nil {
 			return err
@@ -47,9 +47,11 @@ func (vim *VaultInitializationManager) initializeSystem(ctx context.Context) err
 		}
 	}
 
-	err = vim.vaultSystemManager.Unseal(credentials)
-	if err != nil {
-		return err
+	if len(credentials.UnsealKeys) > 0 && credentials.UnsealKeys[0] != "" {
+		err = vim.vaultSystemManager.Unseal(credentials)
+		if err != nil {
+			return err
+		}
 	}
 
 	vim.vaultSystemManager.SetToken(credentials)


### PR DESCRIPTION
The (default) Vault initialization no longer requires an unseal key. If the key is not provided, unsealing Vault will not occur (as this is not going to be necessary in most cases).

More flexibility may be added in the future (i.e. more concrete flags to control whether unsealing and/or initialization should occur, rather than relying on string compares).